### PR TITLE
Update 2019/05/08 00:53 +3GMT

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,7 +24,6 @@
       padding: 0;
       padding: 1.387rem 1.618rem;
       text-align: center;
-      font-size: 1.2em;
       border: 0;
       height: 68px;
       box-sizing: border-box; }
@@ -49,7 +48,6 @@
       margin: 0;
       box-sizing: border-box; }
       .woocommerce-cart-tab-container .widget_shopping_cart .buttons .button {
-        width: 48%;
         float: left;
         margin: 0;
         text-align: center;

--- a/includes/class-cart-tab-customizer.php
+++ b/includes/class-cart-tab-customizer.php
@@ -44,6 +44,7 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 			 * Create defaults from existing options set using the old method
 			 */
 			$cart_tab_position_default = get_option( 'wc_ct_horizontal_position' );
+			$cart_tab_width_buttons_default = '48';
 
 			if ( $cart_tab_position_default ) {
 				delete_option( 'wc_ct_horizontal_position' );
@@ -54,10 +55,17 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 			/**
 			 * Sections
 			 */
-			$wp_customize->add_section( 'woocommerce_cart_tab' , array(
-				'title'    => __( 'Cart Tab', 'storefront' ),
-				'priority' => 85,
-			) );
+			if ( 'storefront' == get_option( 'template' ) ) {
+				$wp_customize->add_section( 'woocommerce_cart_tab' , array(
+					'title'    => __( 'Cart Tab', 'storefront' ),
+					'priority' => 85,
+				) );
+			} else {
+				$wp_customize->add_section( 'woocommerce_cart_tab' , array(
+					'title'    => __( 'Settings panel Cart Tab', 'woocommerce-cart-tab' ),
+					'priority' => 85,
+				) );
+			}
 
 			/**
 			 * Settings
@@ -68,13 +76,25 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 				'sanitize_callback' => 'woocommerce_cart_tab_sanitize_choices',
 			) );
 
+			$wp_customize->add_setting( 'woocommerce_cart_tab_width_buttons' , array(
+				'default'           => $cart_tab_width_buttons_default,
+				'transport'         => 'refresh',
+				'sanitize_callback' => 'woocommerce_cart_tab_sanitize_choices',
+			) );
+
+			$wp_customize->add_setting( 'woocommerce_cart_tab_size_heading' , array(
+				'default'           => '17',
+				'transport'         => 'refresh',
+				'sanitize_callback' => 'woocommerce_cart_tab_sanitize_choices',
+			) );
+
 			$wp_customize->add_setting( 'woocommerce_cart_tab_background', array(
-				'default'           	=> '#ffffff',
+				'default'           	=> '#fff',
 				'sanitize_callback' 	=> 'sanitize_hex_color',
 			) );
 
 			$wp_customize->add_setting( 'woocommerce_cart_tab_accent', array(
-				'default'           	=> '#333333',
+				'default'           	=> '#333',
 				'sanitize_callback' 	=> 'sanitize_hex_color',
 			) );
 
@@ -88,6 +108,16 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 				'sanitize_callback' 	=> 'sanitize_hex_color',
 			) );
 
+			$wp_customize->add_setting( 'woocommerce_cart_tab_text_color', array(
+				'default'           	=> '#333',
+				'sanitize_callback' 	=> 'sanitize_hex_color',
+			) );
+
+			$wp_customize->add_setting( 'woocommerce_cart_tab_list_color', array(
+				'default'           	=> '#5d96ad',
+				'sanitize_callback' 	=> 'sanitize_hex_color',
+			) );
+
 			/**
 			 * Controls
 			 */
@@ -97,8 +127,31 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 				'settings' => 'woocommerce_cart_tab_position',
 				'type'     => 'select',
 				'choices'  => array(
-								'right' => __( 'Right', 'woocommerce-cart-tab' ),
-								'left'  => __( 'Left', 'woocommerce-cart-tab' ),
+					'right' => __( 'Right', 'woocommerce-cart-tab' ),
+					'left'  => __( 'Left', 'woocommerce-cart-tab' ),
+				),
+			) ) );
+
+			$wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'woocommerce_cart_tab_width_buttons', array(
+				'label'    => __( 'Width buttons', 'woocommerce-cart-tab' ),
+				'section'  => 'woocommerce_cart_tab',
+				'settings' => 'woocommerce_cart_tab_width_buttons',
+				'type'     => 'select',
+				'choices'  => array(
+					'48' => __( '50%', 'woocommerce-cart-tab' ),
+					'100'  => __( '100%', 'woocommerce-cart-tab' ),
+				),
+			) ) );
+
+			$wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'woocommerce_cart_tab_size_heading', array(
+				'label'    => __( 'Heading size panel Cart Tab', 'woocommerce-cart-tab' ),
+				'section'  => 'woocommerce_cart_tab',
+				'settings' => 'woocommerce_cart_tab_size_heading',
+				'type'     => 'radio',
+				'choices'  => array(
+					'12' => __( 'Small', 'woocommerce-cart-tab' ),
+					'17'  => __( 'Middle', 'woocommerce-cart-tab' ),
+					'22'  => __( 'Big', 'woocommerce-cart-tab' ),
 				),
 			) ) );
 
@@ -125,6 +178,18 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 				'section'  				=> 'woocommerce_cart_tab',
 				'settings' 				=> 'woocommerce_cart_tab_text_button_color',
 			) ) );
+
+			$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'woocommerce_cart_tab_text_color', array(
+				'label'	   				=> __( 'Color content', 'woocommerce-cart-tab' ),
+				'section'  				=> 'woocommerce_cart_tab',
+				'settings' 				=> 'woocommerce_cart_tab_text_color',
+			) ) );
+
+			$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'woocommerce_cart_tab_list_color', array(
+				'label'	   				=> __( 'Color text list products', 'woocommerce-cart-tab' ),
+				'section'  				=> 'woocommerce_cart_tab',
+				'settings' 				=> 'woocommerce_cart_tab_list_color',
+			) ) );
 		}
 
 		/**
@@ -135,10 +200,15 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 		 * @return void
 		 */
 		public function add_customizer_css() {
-			$background = get_theme_mod( 'woocommerce_cart_tab_background', '#ffffff' );
-			$accent     = get_theme_mod( 'woocommerce_cart_tab_accent', '#333333' );
+			$background = get_theme_mod( 'woocommerce_cart_tab_background', '#fff' );
+			$accent     = get_theme_mod( 'woocommerce_cart_tab_accent', '#333' );
 			$button_color     = get_theme_mod( 'woocommerce_cart_tab_button_color', '#96588a' );
 			$text_button_color     = get_theme_mod( 'woocommerce_cart_tab_text_button_color', '#fff' );
+			$width_buttons     = get_theme_mod( 'woocommerce_cart_tab_width_buttons', '48' );
+			$size_heading     = get_theme_mod( 'woocommerce_cart_tab_size_heading', '17' );
+			$color_content     = get_theme_mod( 'woocommerce_cart_tab_text_color', '#333' );
+			$cart_list_color	=	get_theme_mod( 'woocommerce_cart_tab_list_color', '#5d96ad' );
+
 
 			$styles                = '
 			.woocommerce-cart-tab-container {
@@ -167,7 +237,28 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 			.woocommerce-cart-tab-container .widget_shopping_cart .buttons .button {
 				background-color: ' . $button_color . ';
 				color: ' . $text_button_color . ';
+				width: ' . $width_buttons . '%;
+			}
+
+			.woocommerce-mini-cart__total, .woocommerce-cart-tab-container .widget_shopping_cart .widgettitle {
+				color: ' . $color_content . ';
+			}
+
+			.woocommerce-cart-tab-container .widget_shopping_cart .widgettitle {
+				font-size: ' . $size_heading . 'px;
+			}
+
+			.woocommerce-mini-cart.cart_list.product_list_widget {
+				color: ' . $cart_list_color . ';
 			}';
+
+			if ( $width_buttons == '100' ) {
+				$styles                .= '
+				.woocommerce-cart-tab-container .widget_shopping_cart .buttons .button:first-child {
+					margin-bottom: 10px;
+				}';
+			}
+
 
 			wp_add_inline_style( 'cart-tab-styles', $styles );
 		}

--- a/includes/class-cart-tab-customizer.php
+++ b/includes/class-cart-tab-customizer.php
@@ -78,6 +78,16 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 				'sanitize_callback' 	=> 'sanitize_hex_color',
 			) );
 
+			$wp_customize->add_setting( 'woocommerce_cart_tab_button_color', array(
+				'default'           	=> '#96588a',
+				'sanitize_callback' 	=> 'sanitize_hex_color',
+			) );
+
+			$wp_customize->add_setting( 'woocommerce_cart_tab_text_button_color', array(
+				'default'           	=> '#fff',
+				'sanitize_callback' 	=> 'sanitize_hex_color',
+			) );
+
 			/**
 			 * Controls
 			 */
@@ -103,6 +113,18 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 				'section'  				=> 'woocommerce_cart_tab',
 				'settings' 				=> 'woocommerce_cart_tab_accent',
 			) ) );
+
+			$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'woocommerce_cart_tab_button_color', array(
+				'label'	   				=> __( 'Buttons color', 'woocommerce-cart-tab' ),
+				'section'  				=> 'woocommerce_cart_tab',
+				'settings' 				=> 'woocommerce_cart_tab_button_color',
+			) ) );
+
+			$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'woocommerce_cart_tab_text_button_color', array(
+				'label'	   				=> __( 'Color text buttons', 'woocommerce-cart-tab' ),
+				'section'  				=> 'woocommerce_cart_tab',
+				'settings' 				=> 'woocommerce_cart_tab_text_button_color',
+			) ) );
 		}
 
 		/**
@@ -115,6 +137,8 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 		public function add_customizer_css() {
 			$background = get_theme_mod( 'woocommerce_cart_tab_background', '#ffffff' );
 			$accent     = get_theme_mod( 'woocommerce_cart_tab_accent', '#333333' );
+			$button_color     = get_theme_mod( 'woocommerce_cart_tab_button_color', '#96588a' );
+			$text_button_color     = get_theme_mod( 'woocommerce_cart_tab_text_button_color', '#fff' );
 
 			$styles                = '
 			.woocommerce-cart-tab-container {
@@ -138,6 +162,11 @@ if ( ! class_exists( 'WooCommerce_Cart_Tab_Customizer' ) ) :
 
 			.woocommerce-cart-tab__icon-bag {
 				fill: ' . $accent . ';
+			}
+
+			.woocommerce-cart-tab-container .widget_shopping_cart .buttons .button {
+				background-color: ' . $button_color . ';
+				color: ' . $text_button_color . ';
 			}';
 
 			wp_add_inline_style( 'cart-tab-styles', $styles );

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce Cart Tab ===
-Contributors: jameskoster
-Tags: woocommerce, ecommerce, cart
+Contributors: James Koster
+Tags: woocommerce, ecommerce, cart, tab
 Requires at least: 4.4
-Tested up to: 4.9.6
+Tested up to: 5.2
 Stable tag: 1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -15,16 +15,16 @@ A big UX mistake on many eCommerce web sites is hiding access to the cart. After
 
 This plugin adds a sitewide tab that displays the number of products in the cart. Clicking the tab or adding a product to the cart from a shop page will reveal the cart contents with a link to the checkout.
 
-There are options in the Customizer to control the display.
+Settings of display of a panel are in the menu of the administrator WordPress panel: `Appearance &rarr; Configure &rarr; Tab "Settings panel Cart Tab"`.
 
 Please feel free to contribute on <a href="https://github.com/jameskoster/woocommerce-cart-tab">github</a>.
 
 == Installation ==
 
-1. Upload `woocommerce-cart-tab` to the `/wp-content/plugins/` directory
-2. Activate the plugin through the 'Plugins' menu in WordPress
-3. Choose your display settings on the catalog tab of the WooCommerce settings screen
-3. Done!
+1. Upload `woocommerce-cart-tab` to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' menu in WordPress.
+3. For setup of appearance in the administrator WordPress panel pass: `Appearance &rarr; Configure &rarr; Tab "Settings panel Cart Tab"`.
+4. Done!
 
 == Frequently Asked Questions ==
 
@@ -43,6 +43,11 @@ Thanks! Please fork the repo on <a href="https://github.com/jameskoster/woocomme
 1. The cart tab.
 
 == Changelog ==
+
+= Addition v.1.1.2 from @WSP24
+
+* WooCommerce 3.6 support.
+* The feature for more flexible editing settings of the display of a Cart Tab is added.
 
 = 1.1.2 - 05/07/2018 =
 * Fix - Cart panel will now close automatically when the cart is emptied.


### PR DESCRIPTION
1. The feature for more flexible editing settings of the display of a Cart Tab is added.
2. The plug-in correctly works with WooCoommerce 3.6.2.
3. The plug-in correctly works with WordPress 5.2.
4. In the description instructions as on the page of a plug-in wordpress.org there are negative reviews for the reason that users do not find the section of the setup of a plug-in are updated and ask also similar questions at a forum in a branch of support of a plug-in.